### PR TITLE
fix: Add QuickTime-compatible subtitle track to demo videos

### DIFF
--- a/agents/generate-narration.md
+++ b/agents/generate-narration.md
@@ -211,8 +211,13 @@ for i, (timestamp, text) in enumerate(matches, 1):
 
     text_clean = text.strip()
 
+    # Convert periods to commas for SRT format compliance
+    # SRT spec requires comma as decimal separator: 00:00:05,000 not 00:00:05.000
+    start_srt = start_time.replace('.', ',')
+    end_srt = end_time.replace('.', ',')
+
     srt_content.append(f"{i}")
-    srt_content.append(f"{start_time} --> {end_time}")
+    srt_content.append(f"{start_srt} --> {end_srt}")
     srt_content.append(text_clean)
     srt_content.append("")  # Blank line
 


### PR DESCRIPTION
## Summary

- Fix SRT timestamp format to use commas instead of periods (SRT spec compliance)
- Embed subtitles as toggleable MP4 track using `mov_text` codec instead of just generating VTT files
- Final videos now have three streams: video (h264), audio (aac), subtitles (mov_text)

## Test plan

- [x] Create a demo with narration
- [x] Verify `narration.srt` has comma-formatted timestamps: `00:00:05,000 --> 00:00:10,500`
- [x] Verify `demo_final.mp4` has subtitle stream: `ffprobe -v error -show_entries stream=codec_type,codec_name demo_final.mp4`
- [x] Open in QuickTime → View → Subtitles → English

🤖 Generated with [Claude Code](https://claude.com/claude-code)